### PR TITLE
Fix inco home link + update close btn placement in user modal

### DIFF
--- a/src/client/components/UserMenu.tsx
+++ b/src/client/components/UserMenu.tsx
@@ -131,7 +131,11 @@ const UserMenu = React.forwardRef(function (
         </MenuItem>
       </Menu>
       <Dialog open={openUsernameChange} onClose={handleOnCloseClick}>
-        <DialogTitle>
+        <DialogTitle
+          display={'flex'}
+          justifyContent={'space-between'}
+          alignItems={'center'}
+        >
           Update Username
           <IconButton onClick={handleOnCloseClick}>
             <CloseOutlined />

--- a/src/client/components/menu.tsx
+++ b/src/client/components/menu.tsx
@@ -79,7 +79,7 @@ const BurgerMenu = React.forwardRef(function (
         </MenuItem>
         <MenuItem
           component={Link}
-          href="https://lwtgames.netlify.app/home"
+          href="https://lwtgames.netlify.app"
           target="_blank"
           onClick={handleClose}
         >

--- a/src/client/components/menu.tsx
+++ b/src/client/components/menu.tsx
@@ -63,7 +63,7 @@ const BurgerMenu = React.forwardRef(function (
         <MenuItem onClick={showHowTo}>How to Play</MenuItem>
         <MenuItem
           component={Link}
-          href="https://lwtgames.netlify.app/about"
+          href="https://incocollective.com/about"
           target="_blank"
           onClick={handleClose}
         >
@@ -79,7 +79,7 @@ const BurgerMenu = React.forwardRef(function (
         </MenuItem>
         <MenuItem
           component={Link}
-          href="https://lwtgames.netlify.app"
+          href="https://incocollective.com"
           target="_blank"
           onClick={handleClose}
         >


### PR DESCRIPTION
While in the collab call we noticed the link to the inco website was 404ing.
I updated the route to not hardcode 'home' at that seems to fix it. I think we could also add a redirect from the website side, but this seems like an easy fix for now.

Also tackled an issue where the close btn on the user modal was next to the title instead of to the right of the modal like it should be. 