### PR TITLE
61 fix reset board modal

### DIFF
--- a/src/client/components/Header.tsx
+++ b/src/client/components/Header.tsx
@@ -42,7 +42,11 @@ const Header = React.forwardRef(function ({ toggleTheme }: HeaderProps, ref) {
       justifyContent={'center'}
       alignItems={'center'}
     >
-      {isMobile ? <UnofficialSmall /> : <Unofficial />}
+      {isMobile ? (
+        <UnofficialSmall aria-hidden="true" />
+      ) : (
+        <Unofficial aria-hidden="true" />
+      )}
 
       <Box
         display="flex"
@@ -61,7 +65,11 @@ const Header = React.forwardRef(function ({ toggleTheme }: HeaderProps, ref) {
           Lesbians Who Tech Bingo!
         </Typography>
 
-        {isMobile ? <PresentedByInCoSmall /> : <PresentedByInCo />}
+        {isMobile ? (
+          <PresentedByInCoSmall aria-hidden="true" />
+        ) : (
+          <PresentedByInCo aria-hidden="true" />
+        )}
       </Box>
 
       <Box

--- a/src/client/components/game_elements/board.tsx
+++ b/src/client/components/game_elements/board.tsx
@@ -159,7 +159,6 @@ const Board: React.FC = () => {
 
   const handleClose = () => {
     setLoginOpen(false);
-    resetBoard();
   };
 
   const handleUsernameClose = () => {

--- a/src/client/components/game_elements/board.tsx
+++ b/src/client/components/game_elements/board.tsx
@@ -164,12 +164,10 @@ const Board: React.FC = () => {
 
   const handleUsernameClose = () => {
     setUsernameOpen(false);
-    resetBoard();
   };
 
   const handleScoreSubmissionClose = () => {
     setSubmitScoreOpen(false);
-    resetBoard();
   };
 
   // accessing CSS variables in case we change them later

--- a/src/client/components/game_elements/board.tsx
+++ b/src/client/components/game_elements/board.tsx
@@ -221,10 +221,10 @@ const Board: React.FC = () => {
           variant="secondary"
           onClick={handleResetClicked}
           sx={{
-            width: '8rem',
+            width: '10rem',
           }}
         >
-          Reset Board
+          Get New Board
         </Button>
       </Stack>
       {loginOpen && (

--- a/src/client/components/modals/LoginModal.tsx
+++ b/src/client/components/modals/LoginModal.tsx
@@ -74,7 +74,7 @@ export const LoginModal = ({
               Github Login
             </Button> */}
             <Button variant="secondary" onClick={resetBoard}>
-              No thanks, just reset my board
+              No thanks, give me a new board
             </Button>
           </>
         ) : (

--- a/src/client/components/modals/ScoreSubmissionModal.tsx
+++ b/src/client/components/modals/ScoreSubmissionModal.tsx
@@ -82,7 +82,7 @@ export const ScoreSubmissionModal = ({
             mailing list"
             /> */}
             <Button variant="secondary" onClick={resetBoard}>
-              No thanks, just reset my board
+              No thanks, give me a new board
             </Button>
           </>
         ) : (

--- a/src/client/components/modals/UpdateUsernameModal.tsx
+++ b/src/client/components/modals/UpdateUsernameModal.tsx
@@ -126,7 +126,7 @@ export const UpdateUsernameModal = ({
           Submit to the Leaderboard
         </Button>
         <Button variant="secondary" onClick={handleSubmit}>
-          No thanks, just reset my board
+          No thanks, give me a new board
         </Button>
       </DialogContent>
     </Dialog>

--- a/src/client/components/modals/content/InvalidBoard.tsx
+++ b/src/client/components/modals/content/InvalidBoard.tsx
@@ -26,7 +26,7 @@ const InvalidBoard = ({ onClose, resetBoard }: Props) => {
         Return to my board
       </Button>
       <Button variant="secondary" onClick={resetBoard}>
-        Reset my board
+        Get New Board
       </Button>
     </>
   );

--- a/src/client/components/modals/reset.tsx
+++ b/src/client/components/modals/reset.tsx
@@ -101,7 +101,7 @@ const Reset = React.forwardRef(function (props: ResetProps, ref) {
               className="resetButton"
               onClick={props.reset}
             >
-              Reset Board
+              Give me a new board
             </Button>
           </Stack>
         )}


### PR DESCRIPTION
This PR addresses an issue where clicking "Return to my Board" button resets the board. It is not supposed to do this- it should take the user back to their current bingo board. Removed a couple invocations of resetBoard

Bonus: added aria labels to decorative SVGs, and updated "Reset Board" text to "Get New Board"


Closes #61 
Also closes #57 