### PR TITLE
Fix - Check for Valid Phrases

### DIFF
--- a/src/client/components/game_elements/board.tsx
+++ b/src/client/components/game_elements/board.tsx
@@ -25,14 +25,19 @@ import useAnalytics, { EventName } from '../../../client/hooks/useAnalytics';
 // TODO: conditional color changing for dark vs light since theme colors do not match
 
 // getting a number so we don't have to hard code and continuously update the list of possible phrases
-let length: number = Object.keys(phrases).length;
+const length: number = Object.keys(phrases).length;
+
+// to check if the phrase object contains a phrase
+function isValidPhrase(phraseIndex: number[], length: number): boolean {
+  return phraseIndex.some((index) => index < length);
+}
 
 // gives us unique numbers that will correspond to the phrases to populate the board
 function pickUniqueNumbers(): number[] {
-  let uniqueNumbers: Set<number> = new Set();
+  const uniqueNumbers: Set<number> = new Set();
 
   while (uniqueNumbers.size <= 25) {
-    let randomNumber: number = Math.floor(Math.random() * length) + 1;
+    const randomNumber: number = Math.floor(Math.random() * length) + 1;
     uniqueNumbers.add(randomNumber);
   }
 
@@ -46,9 +51,16 @@ const Board: React.FC = () => {
   const theme = useTheme();
 
   // either going to pull from localStorage, or invoke initial state function
-  const [phraseIndex, setPhraseIndex] = useState<BoardState>(
-    JSON.parse(localStorage.getItem('items')) || initialState()
-  );
+  const [phraseIndex, setPhraseIndex] = useState<BoardState>(() => {
+    const storedData = JSON.parse(localStorage.getItem('items'));
+
+    const valid = isValidPhrase(storedData, length);
+
+    return Array.isArray(storedData) && !valid ? storedData : initialState();
+  });
+
+  // const [phraseIndex, setPhraseIndex] = useState<BoardState>(initialState());
+
   // persisting gameOver state in case of refresh
   const [gameOver, setGameOver] = useState(
     JSON.parse(localStorage.getItem('game over')) || false
@@ -160,6 +172,10 @@ const Board: React.FC = () => {
   // if nothing is in localStorage, we will use this function
   function initialState(): number[] {
     const phrases: number[] = pickUniqueNumbers();
+    // const phrases: number[] = [
+    //   3, 17, 25, 8, 12, 41, 29, 36, 5, 50, 21, 7, 558, 14, 33, 19, 9, 27, 39,
+    //   111, 45, 23, 231, 442,
+    // ];
     localStorage.setItem('items', JSON.stringify(phrases));
     track(EventName.BOARD_INITIALIZED, {
       phrases,


### PR DESCRIPTION
This is meant to fix the issue where a returning user might encounter a blank board if we have changed the amount of phrases.

**To verify:**

In ```board.tsx``` :
- comment out lines 54-60, and uncomment line 62
- also comment out line 174, and uncomment lines 175-178
- refresh your page

This is intentionally setting our localStorage to an array that has values larger than what corresponds to our phrase object. Make sure you see blank squares. Double check localStorage, make sure the array stored as 'items' matches. 

Now do the opposite. (uncomment 54-60, comment out 62, uncomment 174, comment out 175-178). Refresh your page. You should see a full board, and the values in localStorage have changed, because it checks to see if any value in the array is larger than the length of our phrases object.