### PR TITLE
chore: update game name to point back to bingo

### DIFF
--- a/src/firebase/firebase-constants.ts
+++ b/src/firebase/firebase-constants.ts
@@ -1,2 +1,2 @@
 
-export const GAME_NAME = "big-gayme";
+export const GAME_NAME = "bingo";


### PR DESCRIPTION
This points back to the original leaderboard. Tested locally
<img width="1512" alt="Screenshot 2025-04-15 at 9 36 01 PM" src="https://github.com/user-attachments/assets/da4be72b-ab7f-4f97-b70f-871e80253746" />


Can cleanup usernames/scores as needed after. 