### PR TITLE
Inc-138 Correct yellow color on leaderboard user name

### DIFF
--- a/src/client/Components/Leaderboard/LeaderboardCard.tsx
+++ b/src/client/Components/Leaderboard/LeaderboardCard.tsx
@@ -39,16 +39,8 @@ const LeaderboardCard: FunctionComponent<LeaderboardCardProps> = ({
         },
         { fontWeight: score?.id === userId || !!rank ? 'bold' : undefined },
         rank && {
-          backgroundColor: `${
-            theme.palette.mode === 'dark'
-              ? theme.palette.primaryPurple.main
-              : theme.palette.secondaryYellow.main
-          }`,
-          color: `${
-            theme.palette.mode === 'dark'
-              ? theme.palette.common.white
-              : theme.palette.common.black
-          }`,
+          backgroundColor: `${theme.palette.primaryPurple.main}`,
+          color: `${theme.palette.common.white}`,
         },
       ]}
     >

--- a/src/client/Components/Leaderboard/LeaderboardCard.tsx
+++ b/src/client/Components/Leaderboard/LeaderboardCard.tsx
@@ -30,11 +30,7 @@ const LeaderboardCard: FunctionComponent<LeaderboardCardProps> = ({
         {
           border:
             score?.id === userId
-              ? `4px solid ${
-                  theme.palette.mode === 'dark'
-                    ? theme.palette.primaryPurple.main
-                    : theme.palette.primaryPink.main
-                }`
+              ? `4px solid ${theme.palette.primaryPurple.main}`
               : undefined,
         },
         { fontWeight: score?.id === userId || !!rank ? 'bold' : undefined },

--- a/src/client/Components/Leaderboard/LeaderboardCard.tsx
+++ b/src/client/Components/Leaderboard/LeaderboardCard.tsx
@@ -1,5 +1,6 @@
 import React, { FunctionComponent } from 'react';
-import { Card, Grid, useTheme } from '@mui/material';
+import { Card, useTheme } from '@mui/material';
+import Grid from '@mui/material/Grid2';
 import { Score } from './Leaderboard';
 
 interface LeaderboardCardProps {
@@ -11,7 +12,6 @@ interface LeaderboardCardProps {
 }
 
 // this component makes up the name displays on the leaderboard
-// TODO: Grid is deprecated
 
 const LeaderboardCard: FunctionComponent<LeaderboardCardProps> = ({
   index,
@@ -46,15 +46,12 @@ const LeaderboardCard: FunctionComponent<LeaderboardCardProps> = ({
           padding: theme.spacing(0.5, 1),
         }}
       >
-        <Grid item flex={2}>
-          {rank ?? index + 1 ?? ''}
-        </Grid>
+        <Grid flex={2}>{rank ?? index + 1 ?? ''}</Grid>
 
-        <Grid item flex={6} sx={{ textOverflow: 'ellipsis' }}>
+        <Grid flex={6} sx={{ textOverflow: 'ellipsis' }}>
           {score?.username ?? '...'}
         </Grid>
         <Grid
-          item
           alignItems={'flex-end'}
           flex={4}
           textAlign={'right'}


### PR DESCRIPTION
### Purpose 

This PR addresses this ticket about correcting the yellow color showing up for a leaderboard current score. It is now purple. 

[Linear Ticket](https://linear.app/incoteam/issue/INC-138/title-correct-yellow-color-on-leaderboard-user-name)

Also updated the deprecated Grid MUI component in ```LeaderboardCard.tsx``` while there, since all changes for the yellow were in there.